### PR TITLE
Dockerfile: Install Ubuntu package python3-mysqldb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install system-level dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        python3 python3-dev python3-pip \
+        python3 python3-dev python3-pip python3-mysqldb \
         sqlite3 \
         netbase \
         gzip \


### PR DESCRIPTION
In [Dockerfile](./Dockerfile), install Ubuntu package [`python3-mysqldb`](https://packages.ubuntu.com/jammy/python3-mysqldb).

Running `changelog` in Kubernetes causes `ModuleNotFoundError: No module named 'MySQLdb'`.

Installing Ubuntu package [`python3-mysqldb`](https://packages.ubuntu.com/jammy/python3-mysqldb) provides the required module.

```console
❯ kubectl -n changelog logs deployment/changelog
Starting gunicorn with 2 workers, listening on 0.0.0.0:5000
[2024-04-24 09:22:50 +0000] [7] [INFO] Starting gunicorn 22.0.0
[2024-04-24 09:22:50 +0000] [7] [INFO] Listening at: http://0.0.0.0:5000 (7)
[2024-04-24 09:22:50 +0000] [7] [INFO] Using worker: eventlet
[2024-04-24 09:22:50 +0000] [8] [INFO] Booting worker with pid: 8
[2024-04-24 09:22:50 +0000] [9] [INFO] Booting worker with pid: 9
[2024-04-24 09:22:50 +0000] [8] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/arbiter.py", line 609, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/geventlet.py", line 143, in init_process
    super().init_process()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/base.py", line 134, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/base.py", line 146, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python3.10/dist-packages/gunicorn/util.py", line 371, in import_app
    mod = importlib.import_module(module)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/changelog/application.py", line 27, in <module>
    db = SQLAlchemy(app)
  File "/usr/local/lib/python3.10/dist-packages/flask_sqlalchemy/extension.py", line 278, in __init__
    self.init_app(app)
  File "/usr/local/lib/python3.10/dist-packages/flask_sqlalchemy/extension.py", line 374, in init_app
    engines[key] = self._make_engine(key, options, app)
  File "/usr/local/lib/python3.10/dist-packages/flask_sqlalchemy/extension.py", line 665, in _make_engine
    return sa.engine_from_config(options, prefix="")
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/create.py", line 803, in engine_from_config
    return create_engine(url, **options)
  File "<string>", line 2, in create_engine
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/util/deprecations.py", line 281, in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/create.py", line 601, in create_engine
    dbapi = dbapi_meth(**dbapi_args)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/dialects/mysql/mysqldb.py", line 152, in import_dbapi
    return __import__("MySQLdb")
ModuleNotFoundError: No module named 'MySQLdb'
[2024-04-24 09:22:50 +0000] [8] [INFO] Worker exiting (pid: 8)
[...]
```